### PR TITLE
Upgrade to MiniNTup maker output handling

### DIFF
--- a/doc/list-grid-HTopGroupNTup.txt
+++ b/doc/list-grid-HTopGroupNTup.txt
@@ -7,9 +7,9 @@
 #
 # ---------------------------------------
 # ~~~~ ttH125 (signal) ~~~~ #
-#user.dhohn.341270.aMcAtNloHerwigppEvtGen.DAOD_HIGG8D1.e4277_s2608_s2183_r6869_r6282_p2559.29.03.16.Nominal_output.root/
+user.dhohn.341270.aMcAtNloHerwigppEvtGen.DAOD_HIGG8D1.e4277_s2608_s2183_r6869_r6282_p2559.29.03.16.Nominal_output.root/
 # ~~~~ ttbar (background) ~~~~ #
-user.dhohn.410000.PowhegPythiaEvtGen.DAOD_HIGG8D1.e3698_s2608_s2183_r7267_r6282_p2559.29.03.16.Nominal_output.root/
+#user.dhohn.410000.PowhegPythiaEvtGen.DAOD_HIGG8D1.e3698_s2608_s2183_r7267_r6282_p2559.29.03.16.Nominal_output.root/
 # ~~~~ ttW (background) ~~~~ #
 # ~~~~ ttZ(background) ~~~~ #
 # ~~~~ WZ (background) ~~~ #
@@ -17,10 +17,12 @@ user.dhohn.410000.PowhegPythiaEvtGen.DAOD_HIGG8D1.e3698_s2608_s2183_r7267_r6282_
 # ~~~~ Wgamma+jets (background) ~~~ #
 # ~~~~ Zgamma+jets (background) ~~~ #
 # ~~~~ Z+jets (background) ~~~ #
+#user.hpotti.361397.Sherpa.DAOD_HIGG8D1.e3651_s2586_s2174_r7326_r6282_p2559.23.05.16.Nominal_output.root/
 # ~~~~ single t (background) ~~~ #
 # ~~~~ ttWW (background) ~~~~ #
 # ~~~~ bulk MC submission ~~~~ #
 #
+#user.dhohn.*.DAOD_HIGG8D1.*r6282_p2559.29.03.16.Nominal_output.root/
 # ********** #
 #    data    #
 # ********** #

--- a/scripts/jobOptions_HTopMultilepMiniNTupMaker.py
+++ b/scripts/jobOptions_HTopMultilepMiniNTupMaker.py
@@ -26,7 +26,9 @@ lep_branches         = ["lep_ID_0","lep_Index_0","lep_Pt_0","lep_E_0","lep_Eta_0
                         "lep_SFIDLoose_2","lep_SFIDTight_2","lep_SFTrigLoose_2","lep_SFTrigTight_2","lep_SFIsoLoose_2","lep_SFIsoTight_2","lep_SFReco_2","lep_SFTTVA_2","lep_SFObjLoose_2","lep_SFObjTight_2"]
 tau_branches         = ["tau_pt_0","tau_eta_0","tau_phi_0","tau_charge_0","tau_BDTJetScore_0","tau_JetBDTSigLoose_0","tau_JetBDTSigMedium_0","tau_JetBDTSigTight_0","tau_numTrack_0","tau_SFTight_0","tau_SFLoose_0"]
 
-branches_to_copy = eventweight_branches + event_branches + trigbits_branches + jet_branches + lep_branches + tau_branches
+mc_truth_branches = ["m_truth_m","m_truth_pt","m_truth_eta","m_truth_phi","m_truth_e","m_truth_pdgId","m_truth_status","m_truth_barcode","m_truth_parents","m_truth_children","m_truth_jet_pt","m_truth_jet_eta","m_truth_jet_phi","m_truth_jet_e"]
+
+branches_to_copy = eventweight_branches + event_branches + trigbits_branches + jet_branches + lep_branches + tau_branches + mc_truth_branches
 
 # Trick to pass the list as a comma-separated string to the C++ algorithm
 #
@@ -59,7 +61,8 @@ for branch in branches_to_copy:
 algskim = ROOT.EL.AlgSelect(HTopMultilepMiniNTupMakerDict["m_outputNTupStreamName"])
 #algskim.addCut ("passEventCleaning==1")
 algskim.addCut ("HLT_e24_lhmedium_L1EM20VH||HLT_e24_lhmedium_L1EM18VH||HLT_e60_lhmedium||HLT_e120_lhloose||HLT_mu20_iloose_L1MU15||HLT_mu50")
-#algskim.addCut ("nJets_OR>=1")
+algskim.addCut ("nJets_OR>=1") # temp
+algskim.addCut("nJets_OR_MV2c20_77>=1") # temp
 algskim.addCut ("dilep_type>0||trilep_type>0")
 algskim.histName ("cutflow")
 

--- a/scripts/submit-grid-HTopMultilepMiniNTupMaker.py
+++ b/scripts/submit-grid-HTopMultilepMiniNTupMaker.py
@@ -6,10 +6,10 @@ import datetime
 current_time = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
 
 username   = "mmilesi"
-prodtag    = "v7-MiniNTup-01"
+prodtag    = "v7-MiniNTup-Truth-test"
 infilepath = "HTopMultilepAnalysis/doc/list-grid-HTopGroupNTup.txt"
 treename   = "nominal"
-configpath = "$ROOTCOREBIN/user_scripts/HTopMultilepAnalysis/jobOptions_HTopMultilepMiniNtupMaker.py"
+configpath = "$ROOTCOREBIN/user_scripts/HTopMultilepAnalysis/jobOptions_HTopMultilepMiniNTupMaker.py"
 outdir     = "output_grid_DxAOD-2015-13TeV_" + str(current_time)
 destSE     = "AUSTRALIA-ATLAS_LOCALGROUPDISK"
 exclSE     = "ANALY_IHEP,ANALY_JINR,ANALY_IHEP_GLEXEC,ANALY_RRC-KI-HPC,ANALY_RRC-KI-T1,IHEP_MCORE,IHEP_PROD,RRC-KI-HPC2,RRC-KI-T1,RRC-KI-T1_MCORE,RRC-KI-T1_TEST"

--- a/scripts/submit-local-HTopMultilepMiniNTupMaker.py
+++ b/scripts/submit-local-HTopMultilepMiniNTupMaker.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import glob, os, sys, subprocess
+import glob, os, sys, subprocess, shutil
 
 samplescsv = os.path.abspath(os.path.curdir) + "/HTopMultilepAnalysis/PlotUtils/Files/samples2015_HTopMultilep_25ns.csv"
 
@@ -39,7 +39,7 @@ infilelist = [
 #"/coepp/cephfs/mel/mmilesi/ttH/GroupNTup/25ns_v7/Nominal/361085/361085.root",
 #"/coepp/cephfs/mel/mmilesi/ttH/GroupNTup/25ns_v7/Nominal/361086/361086.root",
 #"/coepp/cephfs/mel/mmilesi/ttH/GroupNTup/25ns_v7/Nominal/361087/361087.root",
-#"/coepp/cephfs/mel/mmilesi/ttH/GroupNTup/25ns_v7/Nominal/410000/410000.root",
+"/coepp/cephfs/mel/mmilesi/ttH/GroupNTup/25ns_v7/Nominal/410000/410000.root",
 #"/coepp/cephfs/mel/mmilesi/ttH/GroupNTup/25ns_v7/Nominal/410007/410007.root",
 #"/coepp/cephfs/mel/mmilesi/ttH/GroupNTup/25ns_v7/Nominal/410066/410066.root",
 #"/coepp/cephfs/mel/mmilesi/ttH/GroupNTup/25ns_v7/Nominal/410067/410067.root",
@@ -73,7 +73,7 @@ infilelist = [
 #"/coepp/cephfs/mel/mmilesi/ttH/GroupNTup/25ns_v7/Nominal/361389/361389.root",
 #"/coepp/cephfs/mel/mmilesi/ttH/GroupNTup/25ns_v7/Nominal/361392/361392.root",
 #"/coepp/cephfs/mel/mmilesi/ttH/GroupNTup/25ns_v7/Nominal/361395/361395.root",
-"/coepp/cephfs/mel/mmilesi/ttH/GroupNTup/25ns_v7/Nominal/361397/361397.root",
+#"/coepp/cephfs/mel/mmilesi/ttH/GroupNTup/25ns_v7/Nominal/361397/361397.root",
 #"/coepp/cephfs/mel/mmilesi/ttH/GroupNTup/25ns_v7/Nominal/361398/361398.root",
 #"/coepp/cephfs/mel/mmilesi/ttH/GroupNTup/25ns_v7/Nominal/361401/361401.root",
 #"/coepp/cephfs/mel/mmilesi/ttH/GroupNTup/25ns_v7/Nominal/361404/361404.root",
@@ -167,9 +167,11 @@ infilelist = [
 
 configpath = "$ROOTCOREBIN/user_scripts/HTopMultilepAnalysis/jobOptions_HTopMultilepMiniNTupMaker.py"
 treename   = "nominal"
-nevents    = 0
+nevents    = 10000
 
-motherdir = os.path.abspath(os.path.curdir) + "/25ns_v7"
+#motherdir = "/coepp/cephfs/mel/mmilesi/ttH/MiniNTup/25ns_v7"
+motherdir = "/coepp/cephfs/mel/mmilesi/ttH/MiniNTup/25ns_v7_MCTruth"
+
 if not os.path.exists(motherdir):
     os.makedirs(motherdir)
 for s in sampledict:
@@ -207,10 +209,10 @@ for infile in infilelist:
           separator = ""
 
 	INTREE  = outputfilepath + "/" + outdir + ".root"
-	INHIST  =  outdir + "/hist-" + outdir + ".root"
+	INHIST  = outdir + "/hist-" + outdir + ".root"
 	if ( outdir == "Data" ):
 	   INTREE  = outputfilepath + "/list-local-HTopGroupNTup.root"
-	   INHIST  =  outdir + "/hist-list-local-HTopGroupNTup.root"
+	   INHIST  = outdir + "/hist-list-local-HTopGroupNTup.root"
 
 	OUTTREE = motherdir + "/" + s["group"] + "/" + s["ID"] + separator + s["name"] + ".root"
 	OUTHIST = motherdir + "/" + s["group"] + "/hist-" + s["ID"] + separator + s["name"] + ".root"
@@ -218,5 +220,6 @@ for infile in infilelist:
 	print("Moving :\n{0}\nto:\n{1}".format(INTREE,OUTTREE))
 	print("Moving :\n{0}\nto:\n{1}".format(INHIST,OUTHIST))
 
-	os.rename(INTREE,OUTTREE)
-	os.rename(INHIST,OUTHIST)
+	shutil.move(INTREE,OUTTREE)
+	shutil.move(INHIST,OUTHIST)
+        shutil.rmtree(os.path.abspath(os.path.curdir) + "/" + outdir)


### PR DESCRIPTION
Now output files produced when running on direct driver are moved to /coepp/cephfs/ on the fly during the job, to avoid hitting storage limits of /home 
